### PR TITLE
Remove calls to library assert.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+2019-08-29  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	Remove calls to library assert.
+
+	Assert is not appropriate for benchmark code, and pulls in large
+	amounts of library function code. This patches provides a
+	simplified macro to replace it in two benchmarks.
+
+	This is the fix to GitHub Issue 10, see
+	https://github.com/embench/embench-iot/issues/10
+
+	* src/nettle-aes/nettle-aes.c (_aes_set_key, aes_set_encrypt_key)
+	(aes_encrypt, aes_decrypt): Replace assert with assert_beebs
+	throughout.
+	* src/nettle-sha256/nettle-sha256.c (nettle_hash_digest_func)
+	(sha256_write_digest): Likewise.
+	* support/beebsc.c: Trivial layout space adjustment.
+	* support/beebsc.h (assert_beebs): Macro added.
+
 2019-08-26  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	Add --relative option.

--- a/src/nettle-aes/nettle-aes.c
+++ b/src/nettle-aes/nettle-aes.c
@@ -41,7 +41,7 @@ do {                                            \
 #define ROTL32(n,x) (((x)<<(n)) | ((x)>>((-(n)&31))))
 
 #define FOR_BLOCKS(length, dst, src, blocksize) \
-  assert( !((length) % (blocksize)));           \
+  assert_beebs( !((length) % (blocksize)));           \
   for (; (length); ((length) -= (blocksize),    \
                   (dst) += (blocksize),         \
                   (src) += (blocksize)) )
@@ -730,7 +730,7 @@ _aes_set_key (unsigned nr, unsigned nk,
   unsigned lastkey, i;
   uint32_t t;
 
-  assert (nk != 0);
+  assert_beebs (nk != 0);
   lastkey = (AES_BLOCK_SIZE / 4) * (nr + 1);
 
   for (i = 0, rp = rcon; i < nk; i++)
@@ -757,8 +757,8 @@ aes_set_encrypt_key (struct aes_ctx *ctx, size_t keysize, const uint8_t * key)
 {
   unsigned nk, nr;
 
-  assert (keysize >= AES_MIN_KEY_SIZE);
-  assert (keysize <= AES_MAX_KEY_SIZE);
+  assert_beebs (keysize >= AES_MIN_KEY_SIZE);
+  assert_beebs (keysize <= AES_MAX_KEY_SIZE);
 
   /* Truncate keysizes to the valid key sizes provided by Rijndael */
   if (keysize == AES256_KEY_SIZE)
@@ -1032,7 +1032,7 @@ void
 aes_encrypt (const struct aes_ctx *ctx,
 	     size_t length, uint8_t * dst, const uint8_t * src)
 {
-  assert (!(length % AES_BLOCK_SIZE));
+  assert_beebs (!(length % AES_BLOCK_SIZE));
   _nettle_aes_encrypt (ctx->rounds, ctx->keys, &_aes_encrypt_table,
 		       length, dst, src);
 }
@@ -1044,7 +1044,7 @@ void
 aes_decrypt (const struct aes_ctx *ctx,
 	     size_t length, uint8_t * dst, const uint8_t * src)
 {
-  assert (!(length % AES_BLOCK_SIZE));
+  assert_beebs (!(length % AES_BLOCK_SIZE));
   _nettle_aes_decrypt (ctx->rounds, ctx->keys, &_aes_decrypt_table,
 		       length, dst, src);
 }

--- a/src/nettle-sha256/nettle-sha256.c
+++ b/src/nettle-sha256/nettle-sha256.c
@@ -79,7 +79,7 @@ typedef void nettle_hash_digest_func (void *ctx,
     /* Set the first char of padding to 0x80. This is safe since there  \
        is always at least one byte free */                              \
                                                                         \
-    assert(__md_i < sizeof((ctx)->block));                              \
+    assert_beebs(__md_i < sizeof((ctx)->block));                              \
     (ctx)->block[__md_i++] = 0x80;                                      \
                                                                         \
     if (__md_i > (sizeof((ctx)->block) - (size)))                       \
@@ -353,7 +353,7 @@ sha256_write_digest (struct sha256_ctx *ctx, size_t length, uint8_t * digest)
 {
   uint64_t bit_count;
 
-  assert (length <= SHA256_DIGEST_SIZE);
+  assert_beebs (length <= SHA256_DIGEST_SIZE);
 
   MD_PAD (ctx, 8, COMPRESS);
 

--- a/support/beebsc.c
+++ b/support/beebsc.c
@@ -28,6 +28,7 @@ static void *heap_ptr = NULL;
 static void *heap_end = NULL;
 static size_t heap_requested = 0;
 
+
 /* Yield a sequence of random numbers in the range [0, 2^15-1].
 
    long int is guaranteed to be at least 32 bits. The seed only ever uses 31

--- a/support/beebsc.h
+++ b/support/beebsc.h
@@ -21,6 +21,17 @@
 #endif
 #define RAND_MAX ((1U << 15) - 1)
 
+/* Simplified assert.
+
+   The full complexity of assert is not needed for a benchmark. See the
+   discussion at:
+
+   https://lists.librecores.org/pipermail/embench/2019-August/000007.html 
+
+   This function just*/
+
+#define assert_beebs(expr) { if (!(expr)) exit (1); }
+
 /* Local simplified versions of library functions */
 
 int rand_beebs (void);


### PR DESCRIPTION
	Assert is not appropriate for benchmark code, and pulls in large
	amounts of library function code. This patches provides a
	simplified macro to replace it in two benchmarks.

	This is the fix to GitHub Issue 10, see
	https://github.com/embench/embench-iot/issues/10

ChangeLog:

	* src/nettle-aes/nettle-aes.c (_aes_set_key, aes_set_encrypt_key)
	(aes_encrypt, aes_decrypt): Replace assert with assert_beebs
	throughout.
	* src/nettle-sha256/nettle-sha256.c (nettle_hash_digest_func)
	(sha256_write_digest): Likewise.
	* support/beebsc.c: Trivial layout space adjustment.
	* support/beebsc.h (assert_beebs): Macro added.