### PR TITLE
fix bug

### DIFF
--- a/src/st/libst.c
+++ b/src/st/libst.c
@@ -206,7 +206,7 @@ verify_benchmark (int unused)
   double expSumB = 4996.84311303273534;
   double expCoef = 0.999900054853619324;
 
-  return (fabs (expSumA - SumA) < 1.0e13)
+  return (fabs (expSumA - SumA) < 1.0-e13)
     && (fabs (expSumB - SumB) < 1.0e-13) && (fabs (expCoef - Coef) < 1.0e-17);
 }
 


### PR DESCRIPTION
The difference between `expSumA` and `SumA` should be small enough.