### PR TITLE
Fix floating point accuracy problem

### DIFF
--- a/config/riscv32/boards/ri5cyverilator/boardsupport.h
+++ b/config/riscv32/boards/ri5cyverilator/boardsupport.h
@@ -8,3 +8,5 @@
    SPDX-License-Identifier: GPL-3.0-or-later */
 
 #define CPU_MHZ 1
+#define VERIFY_DOUBLE_EPS 1.0e-13
+#define VERIFY_FLOAT_EPS 1.0e-5

--- a/config/riscv32/chips/size-test-gcc/chip.cfg
+++ b/config/riscv32/chips/size-test-gcc/chip.cfg
@@ -61,7 +61,7 @@
 cc = 'riscv32-unknown-elf-gcc'
 cflags = [
     '-c', '-Os', '-march=rv32imc', '-mabi=ilp32', '-msave-restore',
-    '-fdata-sections', '-ffunction-sections'
+    '-fdata-sections', '-ffunction-sections', '-DHAVE_BOARDSUPPORT_H'
 ]
 ldflags = [
     '-Os', '-march=rv32imc', '-mabi=ilp32', '-msave-restore',

--- a/config/riscv32/chips/size-test-llvm/chip.cfg
+++ b/config/riscv32/chips/size-test-llvm/chip.cfg
@@ -61,7 +61,7 @@
 cc = 'riscv32-unknown-elf-cc'
 cflags = [
     '-c', '-Oz', '-march=rv32imc', '-mabi=ilp32',
-    '-fdata-sections', '-ffunction-sections'
+    '-fdata-sections', '-ffunction-sections', '-DHAVE_BOARDSUPPORT_H'
 ]
 ldflags = [
     '-Oz', '-march=rv32imc', '-mabi=ilp32',

--- a/config/riscv32/chips/speed-test/chip.cfg
+++ b/config/riscv32/chips/speed-test/chip.cfg
@@ -60,7 +60,7 @@
 
 cflags = [
     '-c',  '-O2', '-march=rv32imc', '-mabi=ilp32',
-    '-fdata-sections', '-ffunction-sections'
+    '-fdata-sections', '-ffunction-sections', '-DHAVE_BOARDSUPPORT_H'
 ]
 ldflags = [
     '-O2', '-march=rv32imc', '-mabi=ilp32', '-Wl,-gc-sections'

--- a/src/cubic/basicmath_small.c
+++ b/src/cubic/basicmath_small.c
@@ -27,10 +27,14 @@ static double res1;
 int
 verify_benchmark (int res __attribute ((unused)) )
 {
-  static double exp_res0[3] = {2.0, 6.0, 2.5};
-  return (3 == soln_cnt0) && (fabs (2.0 - res0[0]) < 1.0e-10)
-    && (fabs (6.0 - res0[1]) < 1.0e-10) && (fabs (2.5 - res0[2]) < 1.0e-10)
-    && (1 == soln_cnt1) && (fabs (2.5 - res1) < 1.0e-10);
+  static const double exp_res0[3] = {2.0, 6.0, 2.5};
+  const double exp_res1 = 2.5;
+  return (3 == soln_cnt0)
+    && double_eq_beebs(exp_res0[0], res0[0])
+    && double_eq_beebs(exp_res0[1], res0[1])
+    && double_eq_beebs(exp_res0[2], res0[2])
+    && (1 == soln_cnt1)
+    && double_eq_beebs(exp_res1, res1);
 }
 
 

--- a/src/minver/libminver.c
+++ b/src/minver/libminver.c
@@ -233,11 +233,10 @@ verify_benchmark (int res __attribute ((unused)))
 
   for (i = 0; i < 3; i++)
     for (j = 0; j < 3; j++)
-      if ((fabs (c[i][j] - c_exp[i][j]) > eps)
-	  || (fabs (d[i][j] - d_exp[i][j]) > eps))
+      if (float_neq_beebs(c[i][j], c_exp[i][j]) || float_neq_beebs(d[i][j], d_exp[i][j]))
 	return 0;
 
-  return fabs (det + 16.6666718) <= eps;
+  return float_eq_beebs(det, -16.6666718);
 }
 
 

--- a/src/nbody/nbody.c
+++ b/src/nbody/nbody.c
@@ -257,12 +257,12 @@ verify_benchmark (int unused)
     {
       for (j = 0; j < 3; j++)
 	{
-	  if (solar_bodies[i].x[j] != expected[i].x[j])
+	  if (double_neq_beebs(solar_bodies[i].x[j], expected[i].x[j]))
 	    return 0;
-	  if (solar_bodies[i].v[j] != expected[i].v[j])
+	  if (double_neq_beebs(solar_bodies[i].v[j], expected[i].v[j]))
 	    return 0;
 	}
-      if (solar_bodies[i].mass != expected[i].mass)
+      if (double_neq_beebs(solar_bodies[i].mass, expected[i].mass))
 	return 0;
     }
   return 1;

--- a/src/st/libst.c
+++ b/src/st/libst.c
@@ -206,8 +206,9 @@ verify_benchmark (int unused)
   double expSumB = 4996.84311303273534;
   double expCoef = 0.999900054853619324;
 
-  return (fabs (expSumA - SumA) < 1.0e13)
-    && (fabs (expSumB - SumB) < 1.0e-13) && (fabs (expCoef - Coef) < 1.0e-17);
+  return double_eq_beebs(expSumA, SumA)
+    && double_eq_beebs(expSumB, SumB)
+    && double_eq_beebs(expCoef, Coef);
 }
 
 

--- a/support/beebsc.h
+++ b/support/beebsc.h
@@ -32,6 +32,11 @@
 
 #define assert_beebs(expr) { if (!(expr)) exit (1); }
 
+#define float_eq_beebs(exp, actual) (fabsf(exp - actual) < VERIFY_FLOAT_EPS)
+#define float_neq_beebs(exp, actual) !float_eq_beebs(exp, actual)
+#define double_eq_beebs(exp, actual) (fabs(exp - actual) < VERIFY_DOUBLE_EPS)
+#define double_neq_beebs(exp, actual) !double_eq_beebs(exp, actual)
+
 /* Local simplified versions of library functions */
 
 int rand_beebs (void);


### PR DESCRIPTION
Fix several errors in the places where floating point is used.

ChangeLog:
```
* config/riscv32/boards/ri5cyverilator/boardsupport.h: add error bounds for floating point comparison.
* config/riscv32/chips/size-test-gcc/chip.cfg: add macro to include "boardsupport.h" header.
* config/riscv32/chips/size-test-llvm/chip.cfg: Likewise.
* config/riscv32/chips/speed-test/chip.cfg: Likewise.
* support/beebsc.h: add macros for checking the equality of two floating point numbers.
* src/cubic/basicmath_small.c (verify_benchmark): check the difference between two floating point values using macro defined in beebsc.h
* src/minver/libminver.c (verify_benchmark): Likewise.
* src/nbody/nbody.c (verify_benchmark): Likewise.
* src/st/libst.c (verify_benchmark): Likewise.
```