### PR TITLE
Fix the error in the exception handling

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -445,6 +445,7 @@ def compile_file(f_root, srcdir, bindir):
     # Run the compilation, but only if the source file is newer than the
     # binary.
     succeeded = True
+    res = None
 
     if not os.path.isfile(abs_bin) or (
             os.path.getmtime(abs_src) > os.path.getmtime(abs_bin)
@@ -473,8 +474,9 @@ def compile_file(f_root, srcdir, bindir):
     if not succeeded:
         log.debug('Args to subprocess:')
         log.debug(f'{arglist}')
-        log.debug(res.stdout.decode('utf-8'))
-        log.debug(res.stderr.decode('utf-8'))
+        if res:
+            log.debug(res.stdout.decode('utf-8'))
+            log.debug(res.stderr.decode('utf-8'))
 
     return succeeded
 


### PR DESCRIPTION
In the current implementation of build_all.py, UnboundLocalError exception is raised when the timeout is reached. The following output shows the error log.

```
Traceback (most recent call last):
  File "build_all.py", line 714, in <module>
    sys.exit(main())
  File "build_all.py", line 697, in main
    res = compile_benchmark(bench)
  File "build_all.py", line 505, in compile_benchmark
    succeeded &= compile_file(f_root, abs_src_b, abs_bd_b)
  File "build_all.py", line 477, in compile_file
    log.debug(res.stdout.decode('utf-8'))
UnboundLocalError: local variable 'res' referenced before assignment
```

This pull-request fixes this issue.

ChangeLog:
* build_all.py (compile_file): assign None to res before reference.