### PR TITLE
Avoid use of long double in cubic

### DIFF
--- a/src/cubic/libcubic.c
+++ b/src/cubic/libcubic.c
@@ -26,32 +26,32 @@
 void
 SolveCubic (double a, double b, double c, double d, int *solutions, double *x)
 {
-  long double a1 = (long double) (b / a);
-  long double a2 = (long double) (c / a);
-  long double a3 = (long double) (d / a);
-  long double Q = (a1 * a1 - 3.0L * a2) / 9.0L;
-  long double R = (2.0L * a1 * a1 * a1 - 9.0L * a1 * a2 + 27.0L * a3) / 54.0L;
-  double R2_Q3 = (double) (R * R - Q * Q * Q);
+  double a1 = (b / a);
+  double a2 = (c / a);
+  double a3 = (d / a);
+  double Q = (a1 * a1 - 3.0 * a2) / 9.0;
+  double R = (2.0 * a1 * a1 * a1 - 9.0 * a1 * a2 + 27.0 * a3) / 54.0;
+  double R2_Q3 = (R * R - Q * Q * Q);
 
   double theta;
 
   if (R2_Q3 <= 0)
     {
       *solutions = 3;
-      theta = acos (((double) R) / sqrt ((double) (Q * Q * Q)));
-      x[0] = -2.0 * sqrt ((double) Q) * cos (theta / 3.0) - a1 / 3.0;
+      theta = acos (R / sqrt (Q * Q * Q));
+      x[0] = -2.0 * sqrt (Q) * cos (theta / 3.0) - a1 / 3.0;
       x[1] =
-	-2.0 * sqrt ((double) Q) * cos ((theta + 2.0 * PI) / 3.0) - a1 / 3.0;
+	-2.0 * sqrt (Q) * cos ((theta + 2.0 * PI) / 3.0) - a1 / 3.0;
       x[2] =
-	-2.0 * sqrt ((double) Q) * cos ((theta + 4.0 * PI) / 3.0) - a1 / 3.0;
+	-2.0 * sqrt (Q) * cos ((theta + 4.0 * PI) / 3.0) - a1 / 3.0;
     }
   else
     {
       *solutions = 1;
-      x[0] = pow (sqrt (R2_Q3) + fabs ((double) R), 1 / 3.0);
-      x[0] += ((double) Q) / x[0];
-      x[0] *= (R < 0.0L) ? 1 : -1;
-      x[0] -= (double) (a1 / 3.0L);
+      x[0] = pow (sqrt (R2_Q3) + fabs (R), 1 / 3.0);
+      x[0] += (Q) / x[0];
+      x[0] *= (R < 0.0) ? 1 : -1;
+      x[0] -= (a1 / 3.0);
     }
 }
 


### PR DESCRIPTION
Cubic uses long double which is not standardized. On x86-64 it provides
only 80 bits of precision, but on other architectures it provides either
64 bits or 128 bits of precision.

This not only means that we are doing different computations, but we
are also unfairly penalising architectures that use a 128 bit long
double. Those architectures often have a software emulation library for
128 bit floating point arithmetic. It was also pointed out to me that
the benchmark isn't consistently using long double - it's using double
versions of the transcendental functions.

Fix this by converting all uses of long double to double.

ChangeLog:

        * src/cubic/libcubic.c (SolveCubic): Replace long double with
        double.