### PR TITLE
Use __int128 for 64 x 64 -> 128 bit multiplication if available

### DIFF
--- a/src/aha-mont64/mont64.c
+++ b/src/aha-mont64/mont64.c
@@ -37,9 +37,22 @@ typedef int64_t int64;
 
 /* Multiply unsigned long 64-bit routine, i.e., 64 * 64 ==> 128.
 Parameters u and v are multiplied and the 128-bit product is placed in
-(*whi, *wlo). It is Knuth's Algorithm M from [Knu2] section 4.3.1.
-Derived from muldwu.c in the Hacker's Delight collection. */
+(*whi, *wlo). If __int128 is not defined by the compiler, we fall back
+to Knuth's Algorithm M from [Knu2] section 4.3.1. Derived from muldwu.c
+in the Hacker's Delight collection. */
 
+#ifdef __SIZEOF_INT128__
+void
+mulul64 (uint64 u, uint64 v, uint64 * whi, uint64 * wlo)
+{
+  unsigned __int128 result;
+
+  result = (unsigned __int128)u * v;
+
+  *wlo = result;
+  *whi = result >> 64;
+}
+#else
 void
 mulul64 (uint64 u, uint64 v, uint64 * whi, uint64 * wlo)
 {
@@ -67,6 +80,7 @@ mulul64 (uint64 u, uint64 v, uint64 * whi, uint64 * wlo)
 
   return;
 }
+#endif
 
 /* ---------------------------- modul64 ----------------------------- */
 


### PR DESCRIPTION
aha-mont64 contains an open coded 64 x 64 -> 128 bit multiplication.
This is very sub optimal on 64 bit architectures where we could do
it in 2 instructions.

Fix this by using __int128 if available.

ChangeLog:
        * src/aha-mont64/mont64.c (mulul64): Use __int128 if defined