### PR TITLE
Ensure we use at least Python 3.6.

### DIFF
--- a/benchmark_size.py
+++ b/benchmark_size.py
@@ -27,6 +27,7 @@ sys.path.append(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), 'pylib')
 )
 
+from embench_core import check_python_version
 from embench_core import log
 from embench_core import gp
 from embench_core import setup_logging
@@ -266,7 +267,8 @@ def main():
         sys.exit(1)
 
 
-# Only run if this is the main package
+# Make sure we have new enough Python and only run if this is the main package
 
+check_python_version(3, 6)
 if __name__ == '__main__':
     sys.exit(main())

--- a/benchmark_speed.py
+++ b/benchmark_speed.py
@@ -30,6 +30,7 @@ sys.path.append(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), 'pylib')
 )
 
+from embench_core import check_python_version
 from embench_core import log
 from embench_core import gp
 from embench_core import setup_logging
@@ -245,7 +246,8 @@ def main():
         sys.exit(1)
 
 
-# Only run if this is the main package
+# Make sure we have new enough Python and only run if this is the main package
 
+check_python_version(3, 6)
 if __name__ == '__main__':
     sys.exit(main())

--- a/build_all.py
+++ b/build_all.py
@@ -26,6 +26,7 @@ sys.path.append(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), 'pylib')
 )
 
+from embench_core import check_python_version
 from embench_core import log
 from embench_core import gp
 from embench_core import setup_logging
@@ -708,7 +709,8 @@ def main():
         log.info('All benchmarks built successfully')
 
 
-# Only run if this is the main package
+# Make sure we have new enough Python and only run if this is the main package
 
+check_python_version(3, 6)
 if __name__ == '__main__':
     sys.exit(main())

--- a/pylib/embench_core.py
+++ b/pylib/embench_core.py
@@ -29,6 +29,7 @@ import time
 # What we export
 
 __all__ = [
+    'check_python_version',
     'log',
     'gp',
     'setup_logging',
@@ -42,6 +43,15 @@ log = logging.getLogger()
 
 # All the global parameters
 gp = dict()
+
+
+# Make sure we have new enough python
+def check_python_version(major, minor):
+    """Check the python version is at least {major}.{minor}."""
+    if ((sys.version_info[0] < major)
+        or ((sys.version_info[0] == major) and (sys.version_info[1] < minor))):
+        log.error(f'ERROR: Requires Python {major}.{minor} or later')
+        sys.exit(1)
 
 
 def create_logdir(logdir):


### PR DESCRIPTION
	This fixes issue #20
	(https://github.com/embench/embench-iot/issues/20) raised by
	@quxianmiao

Files changed:

	* benchmark_size.py: import check_python_version from embench_core
	and use it to validate at least Python 3.6 is being used.
	* benchmark_speed.py: Likewise.
	* build_all.py: Likewise.
	* pylib/embench_core.py (check_python_version): Created.