### PR TITLE
Add default arch/chip/board

### DIFF
--- a/config/native/arch.cfg
+++ b/config/native/arch.cfg
@@ -1,0 +1,59 @@
+# Architecture configuration for NATIVE
+#
+# Copyright (C) 2019 Embecosm Limited and the University of Bristol
+#
+# Contributor Graham Markall <graham.markall@embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Ola Jeppsson   <ola.jeppsson@gmail.com>
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# This is a python setting of parameters for the architecture.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.

--- a/config/native/boards/default/board.cfg
+++ b/config/native/boards/default/board.cfg
@@ -1,0 +1,61 @@
+# Board configuration for NATIVE
+#
+# Copyright (C) 2019 Embecosm Limited and the University of Bristol
+#
+# Contributor Graham Markall <graham.markall@embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Ola Jeppsson   <ola.jeppsson@gmail.com>
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# This is a python setting of parameters for the board.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+cpu_mhz = 1

--- a/config/native/boards/default/boardsupport.c
+++ b/config/native/boards/default/boardsupport.c
@@ -1,0 +1,24 @@
+/* Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <support.h>
+
+void
+initialise_board ()
+{
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+}

--- a/config/native/boards/default/boardsupport.h
+++ b/config/native/boards/default/boardsupport.h
@@ -1,0 +1,9 @@
+/* Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#define CPU_MHZ 1

--- a/config/native/chips/default
+++ b/config/native/chips/default
@@ -1,0 +1,1 @@
+speed-test-gcc

--- a/config/native/chips/size-test-gcc/chip.cfg
+++ b/config/native/chips/size-test-gcc/chip.cfg
@@ -1,0 +1,68 @@
+# Chip configuration for no library small size GCC NATIVE Configuration
+#
+# Copyright (C) 2019 Embecosm Limited and the University of Bristol
+#
+# Contributor Graham Markall <graham.markall@embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Ola Jeppsson   <ola.jeppsson@gmail.com>
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# This is a python setting of parameters for the chip.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+cc = 'gcc'
+cflags = [
+    '-c', '-Os', '-fdata-sections', '-ffunction-sections'
+]
+ldflags = [
+    '-Os', '-Wl,-gc-sections', '-nostartfiles', '-nostdlib'
+]
+dummy_libs  = ['crt0', 'libc', 'libgcc', 'libm']

--- a/config/native/chips/size-test-gcc/chipsupport.c
+++ b/config/native/chips/size-test-gcc/chipsupport.c
@@ -1,0 +1,11 @@
+/* Chip support for No-LibC-NoLibGCC NATIVE configuration
+
+   Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "chipsupport.h"

--- a/config/native/chips/size-test-gcc/chipsupport.h
+++ b/config/native/chips/size-test-gcc/chipsupport.h
@@ -1,0 +1,16 @@
+/* Chip support for No-LibC-NoLibGCC NATIVE configuration
+
+   Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+/* Nothing here.  */
+
+#endif

--- a/config/native/chips/speed-test-gcc/chip.cfg
+++ b/config/native/chips/speed-test-gcc/chip.cfg
@@ -1,0 +1,67 @@
+# Chip configuration for Baseline RISC-V Configuration
+#
+# Copyright (C) 2019 Embecosm Limited and the University of Bristol
+#
+# Contributor Graham Markall <graham.markall@embecosm.com>
+# Contributor Jeremy Bennett <jeremy.bennett@embecosm.com>
+# Contributor Ola Jeppsson   <ola.jeppsson@gmail.com>
+#
+# This file is part of Embench.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# This is a python setting of parameters for the chip.  The following
+# parameters may be set (other keys are silently ignored).  Defaults are shown
+# in brackets
+# - cc ('cc')
+# - ld (same value as for cc)
+# - cflags ([])
+# - ldflags ([])
+# - cc_define_pattern ('-D{0}')
+# - cc_incdir_pattern ('-I{0}')
+# - cc_input_pattern ('{0}')
+# - cc_output_pattern ('-o {0}')
+# - ld_input_pattern ('{0}')
+# - ld_output_pattern ('-o {0}')
+# - user_libs ([])
+# - dummy_libs ([])
+# - cpu_mhz (1)
+# - warmup_heat (1)
+
+# The "flags" and "libs" parameters (cflags, ldflags, user_libs, dummy_libs)
+# should be lists of arguments to be passed to the compile or link line as
+# appropriate.  Patterns are Python format patterns used to create arguments.
+# Thus for GCC or Clang/LLVM defined constants can be passed using the prefix
+# '-D', and the pattern '-D{0}' would be appropriate (which happens to be the
+# default).
+
+# "user_libs" may be absolute file names or arguments to the linker. In the
+# latter case corresponding arguments in ldflags may be needed.  For example
+# with GCC or Clang/LLVM is "-l" flags are used in "user_libs", the "-L" flags
+# may be needed in "ldflags".
+
+# Dummy libs have their source in the "support" subdirectory. Thus if 'crt0'
+# is specified, there should be a source file 'dummy-crt0.c' in the support
+# directory.
+
+# There is no need to set an unused parameter, and this file may be empty to
+# set no flags.
+
+# Parameter values which are duplicated in architecture, board, chip or
+# command line are used in the following order of priority
+# - default value
+# - architecture specific value
+# - chip specific value
+# - board specific value
+# - command line value
+
+# For flags, this priority is applied to individual flags, not the complete
+# list of flags.
+
+cflags = [
+    '-c',  '-O2', '-fdata-sections', '-ffunction-sections'
+]
+ldflags = [
+    '-O2', '-Wl,-gc-sections'
+]
+user_libs = ['-lm']

--- a/config/native/chips/speed-test-gcc/chipsupport.c
+++ b/config/native/chips/speed-test-gcc/chipsupport.c
@@ -1,0 +1,11 @@
+/* Chip support for Baseline RISC-V configuration
+
+   Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include "chipsupport.h"

--- a/config/native/chips/speed-test-gcc/chipsupport.h
+++ b/config/native/chips/speed-test-gcc/chipsupport.h
@@ -1,0 +1,16 @@
+/* Chip support for Baseline RISC-V configuration
+
+   Copyright (C) 2019 Clemson University
+
+   Contributor Ola Jeppsson <ola.jeppsson@gmail.com>
+
+   This file is part of Embench.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#ifndef CHIPSUPPORT_H
+#define CHIPSUPPORT_H
+
+/* Nothing here.  */
+
+#endif

--- a/pylib/run_native.py
+++ b/pylib/run_native.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+# Python module to run programs natively.
+
+# Copyright (C) 2019 Clemson University
+#
+# Contributor: Ola Jeppsson <ola.jeppsson@gmail.com>
+#
+# This file is part of Embench.
+
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Embench module to run benchmark programs.
+
+This version is suitable for running programs natively.
+"""
+
+__all__ = [
+    'get_target_args',
+    'build_benchmark_cmd',
+    'decode_results',
+]
+
+import argparse
+import re
+
+from embench_core import log
+
+
+def get_target_args(remnant):
+    """Parse left over arguments"""
+    parser = argparse.ArgumentParser(description='Get target specific args')
+
+    # No target arguments
+    return parser.parse_args(remnant)
+
+
+def build_benchmark_cmd(bench, args):
+    """Construct the command to run the benchmark.  "args" is a
+       namespace with target specific arguments"""
+
+    # Due to way the target interface currently works we need to construct
+    # a command that records both the return value and execution time to
+    # stdin/stdout. Obviously using time will not be very precise.
+    return ['sh', '-c', 'time -p ./' + bench + '; echo RET=$?']
+
+
+def decode_results(stdout_str, stderr_str):
+    """Extract the results from the output string of the run. Return the
+       elapsed time in milliseconds or zero if the run failed."""
+    # See above in build_benchmark_cmd how we record the return value and
+    # execution time. Return code is in standard output. Execution time is in
+    # standard error.
+
+    # Match "RET=rc"
+    rcstr = re.search('^RET=(\d+)', stdout_str, re.S)
+    if not rcstr:
+        log.debug('Warning: Failed to find return code')
+        return 0.0
+
+    # Match "real s.mm?m?"
+    time = re.search('^real (\d+)[.](\d+)', stderr_str, re.S)
+    if time:
+        ms_elapsed = int(time.group(1)) * 1000 + \
+                     int('{:<03d}'.format(int(time.group(2)))) # 0-pad
+        # Return value cannot be zero (will be interpreted as error)
+        return max(float(ms_elapsed), 0.001)
+
+    # We must have failed to find a time
+    log.debug('Warning: Failed to find timing')
+    return 0.0

--- a/support/dummy-libc.c
+++ b/support/dummy-libc.c
@@ -358,6 +358,23 @@ memchr (const void *s __attribute__ ((unused)),
   return 0;
 }
 
+unsigned short int **
+__ctype_b_loc (void)
+{
+  return 0;
+}
+
+unsigned short int **
+__ctype_tolower_loc (void)
+{
+  return 0;
+}
+
+int
+tolower (int c __attribute__ ((unused)))
+{
+  return 0;
+}
 
 /*
    Local Variables:


### PR DESCRIPTION
Add default arch/chip/board.

Default to building/running natively on the host machine when no
target arguments are passed to
build_all.py, benchmark_speed.py & bencmark_size.py.

Files changed:
	benchmark_speed.py: Use 'run_default' as default for target_module.
	build_all.py: Use 'default' as default for arch.
	config/default/arch.cfg: New file.
	support/dummy-libc.c: Add functions needed by x86_64/GCC-9.
	config/default/boards/default/board.cfg: New file.
	config/default/boards/default/boardsupport.c: New file.
	config/default/boards/default/boardsupport.h: New file.
	config/default/chips/default: New symlink 'speed-test-gcc'.
	config/default/chips/size-test-gcc/chip.cfg: New file.
	config/default/chips/size-test-gcc/chipsupport.c: New file.
	config/default/chips/size-test-gcc/chipsupport.h: New file.
	config/default/chips/speed-test-gcc/chip.cfg: New file.
	config/default/chips/speed-test-gcc/chipsupport.c: New file.
	config/default/chips/speed-test-gcc/chipsupport.h: New file.
	pylib/run_default.py: New file.