### PR TITLE
Prerequisites

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -192,6 +192,14 @@ of surname).
 The benchmarks have to be first compiled, then they can then be measured on
 the target.
 
+### Prerequisites
+
+Embench expects the following version of tools. Update your system accordingly.
+
+| _Components_ | _Version_    |
+| -------------| -------------|
+| python       | 3.6          |
+
 ### Preparation
 
 Unpack the software.  Either extract from the supplied _tar_ file:


### PR DESCRIPTION
A quick note _in the documentation_ to make dependencies explicit.

The version of python must be >= 3.6, I've had to browse the commits to find this info.

Plus,

The check implemented in the [pull request #25](https://github.com/embench/embench-iot/pull/25) does not work : as the scripts do not compile ("SyntaxError: invalid syntax" with python 3.4 in my case), the call to check_python_version(3, 6) has no chance to run.

Best regards,
Jean-Francois