### PR TITLE
Add timeout options

### DIFF
--- a/benchmark_speed.py
+++ b/benchmark_speed.py
@@ -73,6 +73,12 @@ def get_common_args():
         required=True,
         help='Python module with routines to run benchmarks',
     )
+    parser.add_argument(
+        '--timeout',
+        type=int,
+        default=30,
+        help='Timeout used for running each benchmark program'
+    )
 
     return parser.parse_known_args()
 
@@ -96,6 +102,7 @@ def validate_args(args):
         sys.exit(1)
 
     gp['absolute'] = args.absolute
+    gp['timeout'] = args.timeout
 
     try:
         newmodule = importlib.import_module(args.target_module)
@@ -126,7 +133,7 @@ def benchmark_speed(bench, target_args):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=appdir,
-                timeout=30,
+                timeout=gp['timeout'],
             )
             if res.returncode != 0:
                 log.warning(f'Warning: Run of {bench} failed.')

--- a/build_all.py
+++ b/build_all.py
@@ -129,6 +129,12 @@ def build_parser():
     parser.add_argument(
         '--clean', action='store_true', help='Rebuild everything'
     )
+    parser.add_argument(
+        '--timeout',
+        type=int,
+        default=5,
+        help='Timeout used for the compiler and linker invocations'
+    )
 
     return parser
 
@@ -251,6 +257,7 @@ def populate_defaults():
     conf['dummy_libs'] = {}
     conf['cpu_mhz'] = 1
     conf['warmup_heat'] = 1
+    conf['timeout'] = 5
 
     return conf
 
@@ -281,7 +288,6 @@ def populate_user_flags(conf, args):
 def populate_user_patterns(conf, args):
     """Populate a dictionary of configuration pattern parameters, "conf", from
        values supplied on the command line in the structure, "args"."""
-    conf = {}
 
     if args.cc_define1_pattern:
         conf['cc_define1_pattern'] = args.cc_define1_pattern
@@ -304,7 +310,6 @@ def populate_user_patterns(conf, args):
 def populate_user_libs(conf, args):
     """Populate a dictionary of configuration library parameters, "conf", from
        values supplied on the command line in the structure, "args"."""
-    conf = {}
 
     if args.user_libs:
         conf['user_libs'] = args.user_libs.split(sep=' ')
@@ -317,12 +322,13 @@ def populate_user_libs(conf, args):
 def populate_user_defs(conf, args):
     """Populate a dictionary of configuration definition parameters, "conf", from
        values supplied on the command line in the structure, "args"."""
-    conf = {}
 
     if args.cpu_mhz:
         conf['cpu_mhz'] = args.cpu_mhz
     if args.warmup_heat:
         conf['warmup_heat'] = args.warmup_heat
+    if args.timeout:
+        conf['timeout'] = args.timeout
 
     return conf
 
@@ -337,7 +343,6 @@ def populate_user(args):
     populate_user_patterns(conf, args)
     populate_user_libs(conf, args)
     populate_user_defs(conf, args)
-
     return conf
 
 
@@ -456,7 +461,7 @@ def compile_file(f_root, srcdir, bindir):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=bindir,
-                timeout=5,
+                timeout=gp['timeout'],
             )
             if res.returncode != 0:
                 log.warning(
@@ -640,7 +645,7 @@ def link_benchmark(bench):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=abs_bd_b,
-            timeout=5,
+            timeout=gp['timeout'],
         )
         if res.returncode != 0:
             log.warning(f'Warning: Link of benchmark "{bench}" failed')

--- a/doc/README.md
+++ b/doc/README.md
@@ -292,6 +292,8 @@ assignments to python variables.  The following parameters may be set.
 - `cpu_mhz`: The clock rate of the target in MHz.  Default value 1.
 - `warmup_heat`: How many times the benchmark code should be run to warm up
   the caches.  Default value 1.
+- `timeout`: The maximum time (in seconds) allowed for the compiler or the
+  linker to run for each invocation. Default value 5.
 
 Any other variables are silently ignored.  There is no need to set an unused
 parameter, and any configuration file may be empty or missing if no flags need
@@ -377,6 +379,8 @@ which takes the following arguments.
 - `--cpu-mhz`: The clock rate of the target in MHz.  Default value 1.
 - `--warmup-heat`: How many times the benchmark code should be run to warm up
   the caches.  Default value 1.
+- `--timeout`: The maximum time (in seconds) allowed for the compiler or the
+  linker to run for each invocation. Default value 5.
 - `--clean`: Delete all intermediaries and final files from any previous runs
   of the script.
 - `--help`: Provide help on the arguments.
@@ -431,6 +435,8 @@ script, which takes the following general arguments.
 - `--target-module <target module>`: This mandatory argument specifies a
   python module in the [`pylib`](../pylib) directory with definitions of
   routines to run the benchmark.
+- `--timeout`: The maximum time (in seconds) allowed for each benchmark program
+  to run. Default value 30.
 - `--help`: Provide help on the arguments.
 
 There is so much variation in how a benchmark can be run that the detailed


### PR DESCRIPTION
When compiling Embench with a debug build of clang I ran into compilation timeouts. When running the benchmark programs with a slow simulator I also ran into benchmark timeouts. These timeout values were hard-coded in the python scripts.

This patch adds options for making the timeouts configurable. As part of the implementation, the patch fixes a bug where the `populate_user_*` functions were discarding the `conf` dictionary value passed as an argument. The documentation is updated accordingly.