### PR TITLE
Fix relative performance calculation

### DIFF
--- a/benchmark_speed.py
+++ b/benchmark_speed.py
@@ -197,7 +197,7 @@ def collect_data(benchmarks, remnant):
                 output = f'{round(raw_data[bench]):8,}'
             else:
                 # Want relative results (the default). Only use non-zero values.
-                rel_data[bench] = raw_data[bench] / baseline[bench]
+                rel_data[bench] = baseline[bench] / raw_data[bench]
                 output = f'  {rel_data[bench]:6.2f}'
 
             log.info(f'{bench:15}  {output:8}')


### PR DESCRIPTION
The relative performance calculation was inverted. I believe my colleague @GregAC had already reported this issue by email, but I independently ran into it, so for convenience I'm providing a pull request to fix it.