### PR TITLE
Add default value to --cpu-mhz attribute of stm32f4-discovery

### DIFF
--- a/pylib/run_stm32f4-discovery.py
+++ b/pylib/run_stm32f4-discovery.py
@@ -46,7 +46,10 @@ def get_target_args(remnant):
         help='Command to invoke the GDB server',
     )
     parser.add_argument(
-        '--cpu-mhz', type=int, help='Processor clock speed in MHz'
+        '--cpu-mhz',
+        type=int,
+        default=1,
+        help='Processor clock speed in MHz'
     )
 
     return parser.parse_args(remnant)


### PR DESCRIPTION
speed benchmark.

	The absence of a --cpu-mhz value on the command line
	when running the speed benchmark caused cpu-mhz to
	default to a None value.

Files changed:

	* pylib/run_stm32f4-discovery.py: default value of
	  --cpu-mhz = 1.