### PR TITLE
Remove dummy asm instructions for stm32f4-discovery

### DIFF
--- a/config/arm/boards/stm32f4-discovery/boardsupport.c
+++ b/config/arm/boards/stm32f4-discovery/boardsupport.c
@@ -52,7 +52,6 @@
 void
 initialise_board ()
 {
-  __asm__ volatile ("mov r0, 0" : : : "memory");
   InitCycleCounter();
   ResetCycleCounter();
 }
@@ -60,14 +59,12 @@ initialise_board ()
 void __attribute__ ((noinline)) __attribute__ ((externally_visible))
 start_trigger ()
 {
-  __asm__ volatile ("mov r0, 0" : : : "memory");
   EnableCycleCounter();
 }
 
 void __attribute__ ((noinline)) __attribute__ ((externally_visible))
 stop_trigger ()
 {
-  __asm__ volatile ("mov r0, 0" : : : "memory");
   ResetCycleCounter();
   DisableCycleCounter();
 }


### PR DESCRIPTION
The dummy instructions in the support functions for the board interfere
with the setting of the cycle counter when compiling with Clang.
Since the support functions now manage the cycle counter there's no
need for dummy instructions.

Files changed:

        * config/arm/boards/stm32f4-discovery/boardsupport.c:
          removed dummy asm instructions.