### PR TITLE
Update links to BEEBS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Patterson, Jeremy Bennett, Palmer Dabbelt, Cesare Garlati, G. S. Madhusudan
 and Trevor Mudge (see https://tmt.knect365.com/risc-v-workshop-zurich/agenda/2#software_embench-tm-a-free-benchmark-suite-for-embedded-computing-from-an-academic-industry-cooperative-towards-the-long-overdue-and-deserved-demise-of-dhrystone).
 
 The benchmarks are largely derived from the Bristol/Embecosm Embedded
-Benchmark Suite (BEEBS, see http://beebs.eu), which in turn draws its material
-from various earlier projects.  A full description and user manual is in the
-[`doc` directory](./doc/README.md).
+Benchmark Suite (BEEBS, see https://beebs.mageec.org/), which in turn draws
+its material from various earlier projects.  A full description and user
+manual is in the [`doc` directory](./doc/README.md).
 
 ## Stable benchmark versions
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -133,8 +133,8 @@ Embench is based on the following principles:
 
 ### The Bristol/Embecosm Embedded Benchmark Suite (BEEBS)
 
-The benchmarks are largely derived from [BEEBS](http://beebs.eu), which in
-turn draws its material from various earlier projects, notably:
+The benchmarks are largely derived from [BEEBS](https://beebs.mageec.org/),
+which in turn draws its material from various earlier projects, notably:
 
 - [MiBench](http://vhosts.eecs.umich.edu/mibench);
 - [the WCET benchmark collection](http://www.mrtc.mdh.se/projects/wcet/benchmarks.html);


### PR DESCRIPTION
	We lost the beebs.eu domain. Update with the replacement domain.

Files changed:

	* README.md: Migrate beebs.eu -> beebs.mageec.org.
	* doc/README.md: Likewise.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>