### PR TITLE
Fix of issue #103

### DIFF
--- a/build_all.py
+++ b/build_all.py
@@ -687,9 +687,6 @@ def link_benchmark(bench):
         log.debug('Command was:')
         log.debug(arglist_to_str(arglist))
 
-    log.debug(res.stdout.decode('utf-8'))
-    log.debug(res.stderr.decode('utf-8'))
-
     return succeeded
 
 

--- a/build_all.py
+++ b/build_all.py
@@ -674,6 +674,10 @@ def link_benchmark(bench):
         if res.returncode != 0:
             log.warning('Warning: Link of benchmark "{bench}" failed'.format(bench=bench))
             succeeded = False
+
+        log.debug(res.stdout.decode('utf-8'))
+        log.debug(res.stderr.decode('utf-8'))
+
     except subprocess.TimeoutExpired:
         log.warning('Warning: link of benchmark "{bench}" timed out'.format(bench=bench))
         succeeded = False


### PR DESCRIPTION
Move the **res** variable log printing inside the **try** block.
clearly the case here is that the _try_ block has failed at _line 666_ and the program is bounced to the exception at _line 677_.
therefore when getting to _line 686_, the **res** variable has not been initialized yet.
hence no one is likely to use the **res** variable outside the try block, the debug log lines are moved inside the **try** block.