### PR TITLE
Make custom malloc & realloc return aligned pointers

### DIFF
--- a/src/huffbench/libhuffbench.c
+++ b/src/huffbench/libhuffbench.c
@@ -57,7 +57,7 @@
 /* BEEBS heap is just an array */
 
 #define HEAP_SIZE 8192
-static char heap[HEAP_SIZE];
+static char heap[HEAP_SIZE] __attribute__((aligned));
 
 #define TEST_SIZE 500
 

--- a/src/sglib-combined/combined.c
+++ b/src/sglib-combined/combined.c
@@ -22,7 +22,7 @@
 /* BEEBS heap is just an array */
 
 #define HEAP_SIZE 8192
-static char heap[HEAP_SIZE];
+static char heap[HEAP_SIZE] __attribute__((aligned));
 
 /* General array to sort for all ops */
 


### PR DESCRIPTION
Fix issue #116.

Until now, `malloc_beebs` and `realloc_beebs` returned non-aligned pointer and this behaviour could result in a performance penalty in some tests that use the heap, especially when executed on some architectures.

This commit makes `malloc_beebs` return pointers aligned to multiples of `sizeof(void *)`, and also updates `realloc_beebs` to make use of that.

To avoid breaking changes, the padding is added to heap_requested.

This commit also makes the static array used as a heap in sglib-combined and huffbench aligned. This is obtained through the `__attribute__((aligned))` directive as it seems to be well supported across compilers.