### PR TITLE
add --benchmark and --exclude option to the benchmark scripts for debugging

### DIFF
--- a/benchmark_size.py
+++ b/benchmark_size.py
@@ -206,6 +206,20 @@ def build_parser():
         help='Section categories to include in metric: one or more of "text", "rodata", '
         + '"data" or "bss". Default "text"',
     )
+    parser.add_argument(
+        '--benchmark',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to measure. By default all tests are measure.'
+    )
+    parser.add_argument(
+        '--exclude',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to exclude.'
+    )
 
     return parser
 
@@ -256,6 +270,9 @@ def validate_args(args):
         gp['metric'] = args.metric
     else:
         gp['metric'] = ['text']
+
+    gp['benchmark'] = args.benchmark
+    gp['exclude'] = args.exclude
 
 def benchmark_size(bench, metrics):
     """Compute the total size of the desired sections in a benchmark.  Returns

--- a/benchmark_speed.py
+++ b/benchmark_speed.py
@@ -132,6 +132,20 @@ def get_common_args():
         action='store_false',
         help='Launch all benchmarks in series (the default)'
     )
+    parser.add_argument(
+        '--benchmark',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to measure. By default all tests are measure.'
+    )
+    parser.add_argument(
+        '--exclude',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to exclude.'
+    )
 
     return parser.parse_known_args()
 
@@ -167,6 +181,9 @@ def validate_args(args):
 
     gp['timeout'] = args.timeout
     gp['sim_parallel'] = args.sim_parallel
+
+    gp['benchmark'] = args.benchmark
+    gp['exclude'] = args.exclude
 
     try:
         newmodule = importlib.import_module(args.target_module)

--- a/build_all.py
+++ b/build_all.py
@@ -121,6 +121,20 @@ def build_parser():
         default=5,
         help='Timeout used for the compiler and linker invocations'
     )
+    parser.add_argument(
+        '--benchmark',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to build. By default all tests are build.'
+    )
+    parser.add_argument(
+        '--exclude',
+        type=str,
+        default=[],
+        nargs='+',
+        help='Benchmark name(s) to exclude.'
+    )
 
     return parser
 
@@ -195,6 +209,9 @@ def validate_args(args):
         for envarg in envlist:
             var, val = envarg.split('=', 1)
             gp['env'][var] = val
+
+    gp['benchmark'] = args.benchmark
+    gp['exclude'] = args.exclude
 
     # Other args validated later.
 

--- a/pylib/embench_core.py
+++ b/pylib/embench_core.py
@@ -130,11 +130,16 @@ def find_benchmarks():
        Return the list of benchmarks."""
     gp['benchdir'] = os.path.join(gp['rootdir'], 'src')
     gp['bd_benchdir'] = os.path.join(gp['bd'], 'src')
-    dirlist = os.listdir(gp['benchdir'])
+    if gp['benchmark']:
+        dirlist = gp['benchmark']
+    else:
+        dirlist = os.listdir(gp['benchdir'])
 
     benchmarks = []
 
     for bench in dirlist:
+        if bench in gp['exclude']:
+            continue
         abs_b = os.path.join(gp['benchdir'], bench)
         if os.path.isdir(abs_b):
             benchmarks.append(bench)


### PR DESCRIPTION
This PR adds `--benchmark` and `--exclude` option to `build_all.py`, `benchmark_size.py`, and `benchmark_speed.py`.
For example `--benchmark md5sum tarfind` option builds or measures only `md5sum` and `tarfind` tests.
`--exclude md5sum tarfind` option builds or measures all tests except for `md5sum` and `tarfind`.

This was quite useful for debugging.
