### PR TITLE
Tarfind: fix heap size to be multiple of the pointer size

### DIFF
--- a/src/tarfind/tarfind.c
+++ b/src/tarfind/tarfind.c
@@ -20,7 +20,9 @@
 #define N_SEARCHES 5
 
 /* BEEBS heap is just an array */
-#define HEAP_SIZE 8995
+/* 8995 = sizeof(tar_header_t) * ARCHIVE_FILES */
+#define roundup(d, u) ((((d)+(u))/(u))*(u))
+#define HEAP_SIZE roundup(8995, sizeof(void *))
 static char heap[HEAP_SIZE];
 
 void

--- a/support/beebsc.c
+++ b/support/beebsc.c
@@ -17,6 +17,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <assert.h>
 #include "beebsc.h"
 
 /* Seed for the random number generator */
@@ -61,6 +62,7 @@ srand_beebs (unsigned int new_seed)
 void
 init_heap_beebs (void *heap, size_t heap_size)
 {
+  assert(heap_size % sizeof(void *) == 0);  /* see #138 */
   heap_ptr = (void *) heap;
   heap_end = (void *) ((char *) heap_ptr + heap_size);
   heap_requested = 0;


### PR DESCRIPTION
The fix #138 requires that the heap size must be multiple of the pointer size.
The heap size of tarfind.c was 8995. As the result malloc() failed.

An assertion check was added on init_heap_beebs. No other benchmarks failed.