### PR TITLE
md5sum: make calloc() use calloc_beebs() and use XOR for result value

### DIFF
--- a/src/md5sum/md5.c
+++ b/src/md5sum/md5.c
@@ -24,7 +24,7 @@
  * of 1000 and a msg initiated incrementally from 0 to 999 as in benchmark_body.
  * If MSG_SIZE or the initialization mechanism of the array change the RESULT
  * value needs to be updated accordingly. */
-#define RESULT 0x30C0DA225
+#define RESULT 0x33f673b4
 
 static char heap[HEAP_SIZE];
 
@@ -231,7 +231,7 @@ benchmark_body (int rpt, int len)
     printf("%2.2x%2.2x%2.2x%2.2x\n", p[0], p[1], p[2], p[3]);
   }
 
-  return h0 + h1 + h2 + h3;
+  return h0 ^ h1 ^ h2 ^ h3;
 }
 
 

--- a/src/md5sum/md5.c
+++ b/src/md5sum/md5.c
@@ -17,7 +17,8 @@
 #define LOCAL_SCALE_FACTOR 51
 
 /* BEEBS heap is just an array */
-#define HEAP_SIZE 2000
+/* MSG_SIZE * 2 + ((((MSG_SIZE+8)/64 + 1) * 64) - 8) + 64 */
+#define HEAP_SIZE (2000 + 1016 + 64)
 #define MSG_SIZE 1000
 /* Result obtained with a single run on the native target on x86 with a MSG_SIZE
  * of 1000 and a msg initiated incrementally from 0 to 999 as in benchmark_body.
@@ -82,7 +83,7 @@ void md5(uint8_t *initial_msg, size_t initial_len) {
 
     int new_len = ((((initial_len + 8) / 64) + 1) * 64) - 8;
 
-    msg = calloc(new_len + 64, 1); // also appends "0" bits
+    msg = calloc_beebs(new_len + 64, 1); // also appends "0" bits
                                    // (we alloc also 64 extra bytes...)
     memcpy(msg, initial_msg, initial_len);
     msg[initial_len] = 128; // write the "1" bit
@@ -172,7 +173,7 @@ void md5(uint8_t *initial_msg, size_t initial_len) {
     }
 
     // cleanup
-    free(msg);
+    free_beebs(msg);
 }
 
 


### PR DESCRIPTION
Although malloc_beebs() was used for malloc(), but calloc_beebs() was not used for calloc().
As result calloc() failed.
Use calloc_beebs() for calloc() and increase the heap size for it.

---

The result value was the sum of four uint32_t values.
The result changes between 32bit and 64bit CPUs.

Using XOR (Exclusive OR) fixes the issue.