### PR TITLE
Remove debug printfs from md5sum

### DIFF
--- a/src/md5sum/md5.c
+++ b/src/md5sum/md5.c
@@ -214,7 +214,7 @@ benchmark_body (int rpt, int len)
     }
     md5(msg, len);
     free_beebs(msg);
-
+#ifdef DEBUG
     uint8_t *p;
     // display result
     p=(uint8_t *)&h0;
@@ -228,6 +228,7 @@ benchmark_body (int rpt, int len)
 
     p=(uint8_t *)&h3;
     printf("%2.2x%2.2x%2.2x%2.2x\n", p[0], p[1], p[2], p[3]);
+#endif
   }
 
   return h0 + h1 + h2 + h3;


### PR DESCRIPTION
This commit removes printfs from md5sum test, as they can influence test results.
Signed-off-by: Maciej Dudek <mdudek@antmicro.com>