### PR TITLE
fix md5sum RET parse error

### DIFF
--- a/pylib/run_native.py
+++ b/pylib/run_native.py
@@ -54,7 +54,7 @@ def decode_results(stdout_str, stderr_str):
     # standard error.
 
     # Match "RET=rc"
-    rcstr = re.search('^RET=(\d+)', stdout_str, re.S)
+    rcstr = re.search('^RET=(\d+)', stdout_str, re.S | re.M)
     if not rcstr:
         log.debug('Warning: Failed to find return code')
         return 0.0


### PR DESCRIPTION
When run_native like below, I get a error and find md5sum's RET check error. I found the regexp pattern for stdout RET line has a bug when stdout has multiline and RET line not the first line ( or maby md5sum program should not produce output).
```
./benchmark_speed.py --target-module run_native
Benchmark           Speed
---------           -----
aha-mont64         4004000.00
crc32              4010000.00
cubic              3931000.00
edn                4010000.00
huffbench          4120000.00
matmult-int        3985000.00
md5sum                   
minver             3998000.00
nbody              2808000.00
nettle-aes         4026000.00
nettle-sha256      3997000.00
nsichneu           4001000.00
picojpeg           4030000.00
primecount         3834000.00
qrduino            4253000.00
sglib-combined     3981000.00
slre               4010000.00
st                 4080000.00
statemate          4001000.00
tarfind            4033000.00
ud                 3999000.00
wikisort           2779000.00
ERROR: Failed to compute speed benchmarks
```

log is below:

```
Warning: Failed to find return code
Args to subprocess:
sh '-c' 'time -p ./md5sum; echo RET=$?'
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
cbecbdb0fdd5cec1e242493b6008cc79
RET=0
```