### PR TITLE
jsonfix for embench 1.0

### DIFF
--- a/benchmark_size.py
+++ b/benchmark_size.py
@@ -289,7 +289,7 @@ def collect_data(benchmarks):
 
     # Output it
     if gp['output_format'] == output_format.JSON:
-        log.info('  "size results" :')
+        log.info('{ "size results" :')
         log.info('  { "detailed size results" :')
         for bench in benchmarks:
             res_output = ''
@@ -376,7 +376,8 @@ def main():
         if gp['output_format'] != output_format.BASELINE:
             opt_comma = ',' if args.json_comma else ''
             embench_stats(benchmarks, raw_data, rel_data, 'size', opt_comma)
-            log.info('All benchmarks sized successfully')
+            if gp['output_format'] == output_format.JSON: log.info('}')
+            else: log.info('All benchmarks sized successfully')
     else:
         log.info('ERROR: Failed to compute size benchmarks')
         sys.exit(1)

--- a/benchmark_speed.py
+++ b/benchmark_speed.py
@@ -297,7 +297,7 @@ def collect_data(benchmarks, remnant):
 
     # Output it
     if gp['output_format'] == output_format.JSON:
-        log.info('  "speed results" :')
+        log.info('{  "speed results" :')
         log.info('  { "detailed speed results" :')
         for bench in benchmarks:
             output = ''
@@ -375,7 +375,8 @@ def main():
         if gp['output_format'] != output_format.BASELINE:
             opt_comma = ',' if args.json_comma else ''
             embench_stats(benchmarks, raw_data, rel_data, 'speed', opt_comma)
-            log.info('All benchmarks run successfully')
+            if gp['output_format'] == output_format.JSON: log.info('}')
+            else: log.info('All benchmarks run successfully')
     else:
         log.info('ERROR: Failed to compute speed benchmarks')
         sys.exit(1)

--- a/pylib/embench_core.py
+++ b/pylib/embench_core.py
@@ -263,7 +263,7 @@ def output_stats(geomean, geosd, georange, count, bm_type, opt_comma):
     if gp['output_format'] == output_format.JSON:
         log.info('    "{bm} geometric mean" : {gmo},'.format(bm=bm_type, gmo=geomean_op))
         log.info('    "{bm} geometric standard deviation" : {gso}'.format(bm=bm_type, gso=geosd_op))
-        log.info('  }{oc}'.format(oc=opt_comma))
+        log.info('  }' + '{oc}'.format(oc=opt_comma))
     elif gp['output_format'] == output_format.TEXT:
         log.info('---------           -----')
         log.info('Geometric mean   {gmo:8}'.format(gmo=geomean_op))


### PR DESCRIPTION
Sister push to jsonfix, this fixes the same issue in the Embench-1.0-branch which is stable. 

Contains the fixes for the JSON file output. The extra { and } in the benchmark_speed.py and benchmark_size.py let the json output be correctly inputted by computers. For JSON outputs, we do not want to print All benchmarks sized successfully, as this ruins the json file. Failed runs will not have the trailing }.

On the Embench_core.py file, the .format python function looks for { and } in the string. Because we need a }, the .format function gets confused and wonders why there isn't a { to give the bounds of what to replace. Currently, this throws a pretty nasty error (at least on my machine). We can fix this by using string concatenation.

log.info(' }' + '{oc}'.format(oc=opt_comma))