### PR TITLE
Wally Embench 1.0 Linker File Bug

### DIFF
--- a/config/riscv32/boards/rv32wallyverilog/link.ld
+++ b/config/riscv32/boards/rv32wallyverilog/link.ld
@@ -161,6 +161,7 @@ SECTIONS
   .data.rel.ro : { *(.data.rel.ro.local* .gnu.linkonce.d.rel.ro.local.*) *(.data.rel.ro .data.rel.ro.* .gnu.linkonce.d.rel.ro.*) }
   .dynamic        : { *(.dynamic) }
   . = DATA_SEGMENT_RELRO_END (0, .);
+  . = ALIGN(0x4);
   .data           :
   {
     __DATA_BEGIN__ = .;
@@ -173,6 +174,7 @@ SECTIONS
   /* We want the small data sections together, so single-instruction offsets
      can access them all, and initialized data all before uninitialized, so
      we can shorten the on-disk segment size.  */
+  . = ALIGN(0x4);
   .sdata          :
   {
     __SDATA_BEGIN__ = .;


### PR DESCRIPTION
We found a bug causing qrduino to stall in Embench 1.0 on Wally. Weird we didn't see this earlier, but here's the simple fix. 