### PR TITLE
Guard md5sum printf by DEBUG

### DIFF
--- a/src/md5sum/md5.c
+++ b/src/md5sum/md5.c
@@ -218,6 +218,7 @@ benchmark_body (int rpt, int len)
 
     uint8_t *p;
     // display result
+#ifdef DEBUG
     p=(uint8_t *)&h0;
     printf("%2.2x%2.2x%2.2x%2.2x", p[0], p[1], p[2], p[3]);
 
@@ -229,6 +230,7 @@ benchmark_body (int rpt, int len)
 
     p=(uint8_t *)&h3;
     printf("%2.2x%2.2x%2.2x%2.2x\n", p[0], p[1], p[2], p[3]);
+#endif
   }
 
   return h0 ^ h1 ^ h2 ^ h3;


### PR DESCRIPTION
The md5sum benchmark included `printf` calls which were not guarded by any flag, meaning that the benchmark relied on stdout and requires any platform to support linking against a functional libc implementation.

With the added `#DEBUG` guard, none of the benchmarks perform I/O.