### PR TITLE
[fix]:KeyError Exception thrown by benchmark_size.py when missing baseline data

### DIFF
--- a/benchmark_size.py
+++ b/benchmark_size.py
@@ -297,9 +297,13 @@ def collect_data(benchmarks):
             # Want relative results (the default). If baseline is zero, just
             # use 0.0 as the value.  Note this is inverted compared to the
             # speed benchmark, so SMALL is good.
-            if baseline[bench] > 0:
-                rel_data[bench] = raw_totals[bench] / baseline[bench]
-            else:
+            try:
+                if baseline[bench] > 0:
+                    rel_data[bench] = raw_totals[bench] / baseline[bench]
+                else:
+                    rel_data[bench] = 0.0
+            except KeyError:
+                log.error(f'Baseline data for {bench} not found. Assuming 0.')
                 rel_data[bench] = 0.0
 
     # Output it

--- a/examples/or1k/README.md
+++ b/examples/or1k/README.md
@@ -1,0 +1,7 @@
+# Configuration
+
+## Building
+
+```sh
+scons --config-dir=examples/or1k/ user_libs=-lm cc=or1k-elf-gcc cflags "-c -Wall -O2 -ffunction-sections -mhard-mul -mhard-div -mhard-float -mdouble-float -mror" ldflags="-Wl,-gc-sections"
+```

--- a/examples/or1k/boardsupport.c
+++ b/examples/or1k/boardsupport.c
@@ -1,0 +1,28 @@
+/* Copyright (C) 2017 Embecosm Limited and University of Bristol
+
+   Contributor Madhu Sudhanan <madhu2000u@gmail.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <support.h>
+
+void
+initialise_board ()
+{
+  
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+start_trigger ()
+{
+  
+}
+
+void __attribute__ ((noinline)) __attribute__ ((externally_visible))
+stop_trigger ()
+{
+  
+}

--- a/examples/or1k/boardsupport.h
+++ b/examples/or1k/boardsupport.h
@@ -1,0 +1,10 @@
+/* Copyright (C) 2017 Embecosm Limited and University of Bristol
+
+   Contributor Madhu Sudhanan <madhu2000u@gmail.com>
+
+   This file is part of Embench and was formerly part of the Bristol/Embecosm
+   Embedded Benchmark Suite.
+
+   SPDX-License-Identifier: GPL-3.0-or-later */
+
+#define CPU_MHZ 1


### PR DESCRIPTION
When collecting the relative results, it compares with baseline data. Recently Depthconv benchmark was added with this commit [07282ee](https://github.com/embench/embench-iot/commit/07282eea14477a3a0c3fee54281c36d6e5561ca3) but a baseline data was not added to the baseline-data/size.json. 

This commit does not add a baseline data for Depthconv into baseline-data/size.json but rather adds error handling in benchmark_size.py should any new benchmarks get added but a baseline data is not included.