### PR TITLE
[fix]: KeyError Exception thrown by benchmark_size.py when missing baseline data

### DIFF
--- a/benchmark_size.py
+++ b/benchmark_size.py
@@ -297,9 +297,13 @@ def collect_data(benchmarks):
             # Want relative results (the default). If baseline is zero, just
             # use 0.0 as the value.  Note this is inverted compared to the
             # speed benchmark, so SMALL is good.
-            if baseline[bench] > 0:
-                rel_data[bench] = raw_totals[bench] / baseline[bench]
-            else:
+            try:
+                if baseline[bench] > 0:
+                    rel_data[bench] = raw_totals[bench] / baseline[bench]
+                else:
+                    rel_data[bench] = 0.0
+            except KeyError:
+                log.error(f'Baseline data for {bench} not found. Assuming 0.')
                 rel_data[bench] = 0.0
 
     # Output it


### PR DESCRIPTION
When collecting the relative results, it compares with baseline data. Recently, Depthconv benchmark was added with this commit [07282ee](https://github.com/embench/embench-iot/commit/07282eea14477a3a0c3fee54281c36d6e5561ca3) but a baseline data was not added to the baseline-data/size.json.

This commit does not add a baseline data for Depthconv into baseline-data/size.json but rather adds error handling in benchmark_size.py should any new benchmarks get added but a baseline data is not included.