### PR TITLE
Fix wikisort bool c11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Wrapper Makefile for embench-iot integration with rv32emu
+#
+# This translates the rv32emu build system's CC/BINDIR variables
+# into the scons-based build system used by embench-iot.
+
+BINDIR  ?= bin
+CC      ?= riscv-none-elf-gcc
+CFLAGS  ?= -march=rv32imac_zicsr -mabi=ilp32 -std=c99
+
+EMBENCH_BUILD_DIR := $(abspath $(BINDIR))/embench-iot-build
+EMBENCH_CONFIG    := examples/riscv32/rv32emu
+
+SHELL_HACK := $(shell mkdir -p $(abspath $(BINDIR)))
+
+.PHONY: all clean
+
+all:
+	scons \
+	    --config-dir=$(EMBENCH_CONFIG) \
+	    --build-dir=$(EMBENCH_BUILD_DIR) \
+	    cc=$(CC) \
+	    cflags="$(CFLAGS)" \
+	    user_libs=-lm
+	find $(EMBENCH_BUILD_DIR)/src -maxdepth 2 -type f ! -name '*.*' \
+	    -exec cp {} $(abspath $(BINDIR)) \;
+
+clean:
+	$(RM) -r $(EMBENCH_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 BINDIR  ?= bin
 CC      ?= riscv-none-elf-gcc
-CFLAGS  ?= -march=rv32imac_zicsr -mabi=ilp32 -std=c99
+CFLAGS  ?= -std=c99
 
 EMBENCH_BUILD_DIR := $(abspath $(BINDIR))/embench-iot-build
 EMBENCH_CONFIG    := examples/riscv32/rv32emu

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 BINDIR  ?= bin
 CC      ?= riscv-none-elf-gcc
 CFLAGS  ?=
+LDFLAGS ?=
 
 EMBENCH_BUILD_DIR := $(abspath $(BINDIR))/embench-iot-build
 EMBENCH_CONFIG    := examples/riscv32/rv32emu
@@ -20,7 +21,9 @@ all:
 	    --build-dir=$(EMBENCH_BUILD_DIR) \
 	    cc=$(CC) \
 	    cflags="$(CFLAGS) -std=c99" \
-	    user_libs=-lm
+	    ldflags="$(CFLAGS)" \
+	    user_libs="$(LDFLAGS)" \
+	    
 	find $(EMBENCH_BUILD_DIR)/src -maxdepth 2 -type f ! -name '*.*' \
 	    -exec cp {} $(abspath $(BINDIR)) \;
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 BINDIR  ?= bin
 CC      ?= riscv-none-elf-gcc
-CFLAGS  ?= -std=c99
+CFLAGS  ?=
 
 EMBENCH_BUILD_DIR := $(abspath $(BINDIR))/embench-iot-build
 EMBENCH_CONFIG    := examples/riscv32/rv32emu
@@ -19,7 +19,7 @@ all:
 	    --config-dir=$(EMBENCH_CONFIG) \
 	    --build-dir=$(EMBENCH_BUILD_DIR) \
 	    cc=$(CC) \
-	    cflags="$(CFLAGS)" \
+	    cflags="$(CFLAGS) -std=c99" \
 	    user_libs=-lm
 	find $(EMBENCH_BUILD_DIR)/src -maxdepth 2 -type f ! -name '*.*' \
 	    -exec cp {} $(abspath $(BINDIR)) \;

--- a/examples/riscv32/rv32emu/boardsupport.c
+++ b/examples/riscv32/rv32emu/boardsupport.c
@@ -10,11 +10,15 @@ initialise_board(void)
 void __attribute__((noinline)) __attribute__((externally_visible))
 start_trigger(void)
 {
+#if defined(__riscv)
     __asm__ volatile("li a0, 0" : : : "memory");
+#endif
 }
 
 void __attribute__((noinline)) __attribute__((externally_visible))
 stop_trigger(void)
 {
+#if defined(__riscv)
     __asm__ volatile("li a0, 0" : : : "memory");
+#endif
 }

--- a/examples/riscv32/rv32emu/boardsupport.c
+++ b/examples/riscv32/rv32emu/boardsupport.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <support.h>
+
+void
+initialise_board(void)
+{
+}
+
+void __attribute__((noinline)) __attribute__((externally_visible))
+start_trigger(void)
+{
+    __asm__ volatile("li a0, 0" : : : "memory");
+}
+
+void __attribute__((noinline)) __attribute__((externally_visible))
+stop_trigger(void)
+{
+    __asm__ volatile("li a0, 0" : : : "memory");
+}

--- a/examples/riscv32/rv32emu/boardsupport.h
+++ b/examples/riscv32/rv32emu/boardsupport.h
@@ -1,0 +1,1 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */

--- a/src/wikisort/libwikisort.c
+++ b/src/wikisort/libwikisort.c
@@ -30,11 +30,7 @@
 #include <limits.h>
 
 /* various #defines for the C code */
-#ifndef true
-#define true 1
-#define false 0
-typedef uint8_t bool;
-#endif
+#include <stdbool.h>
 
 #define Var(name, value, type) type name = value
 


### PR DESCRIPTION
## Problem

GCC 15 defaults to `-std=gnu23` where `bool`, `true`, and `false` are
language keywords. The existing guard `#ifndef true` no longer works,
and `typedef uint8_t bool` fails with:
```
error: two or more data types in declaration specifiers
```

## Fix

Replace the custom bool/true/false block with `#include <stdbool.h>`,
which is available since C99 and is a no-op under C23.

Tested with `riscv-none-elf-gcc` (GCC 15) targeting rv32imac.