### PR TITLE
fix(wikisort): replace custom bool typedef with stdbool.h

### DIFF
--- a/src/wikisort/libwikisort.c
+++ b/src/wikisort/libwikisort.c
@@ -30,11 +30,7 @@
 #include <limits.h>
 
 /* various #defines for the C code */
-#ifndef true
-#define true 1
-#define false 0
-typedef uint8_t bool;
-#endif
+#include <stdbool.h>
 
 #define Var(name, value, type) type name = value
 


### PR DESCRIPTION
GCC 15 defaults to C23 where bool/true/false are keywords, causing 'typedef uint8_t bool' to fail with:
  error: two or more data types in declaration specifiers

Replace the custom bool/true/false definitions with #include <stdbool.h>, which is available since C99 and is a no-op under C23.