### PR TITLE
Add rv32emu board support

### DIFF
--- a/examples/riscv32/rv32emu/boardsupport.c
+++ b/examples/riscv32/rv32emu/boardsupport.c
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
+#include <support.h>
+
+void
+initialise_board(void)
+{
+}
+
+void __attribute__((noinline)) __attribute__((externally_visible))
+start_trigger(void)
+{
+#if defined(__riscv)
+    __asm__ volatile("li a0, 0" : : : "memory");
+#endif
+}
+
+void __attribute__((noinline)) __attribute__((externally_visible))
+stop_trigger(void)
+{
+#if defined(__riscv)
+    __asm__ volatile("li a0, 0" : : : "memory");
+#endif
+}

--- a/examples/riscv32/rv32emu/boardsupport.h
+++ b/examples/riscv32/rv32emu/boardsupport.h
@@ -1,0 +1,1 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */


### PR DESCRIPTION
## Summary

Add board configuration for rv32emu, a RISC-V RV32 instruction set
simulator (https://github.com/sysprog21/rv32emu).

This follows the existing board support pattern under `examples/riscv32/`.

## Files added

- `examples/riscv32/rv32emu/boardsupport.c`
- `examples/riscv32/rv32emu/boardsupport.h`